### PR TITLE
Fix regeneration behaviour

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -779,6 +779,7 @@ class MainWindow(QMainWindow):
         fname = self.images[self.idx].name
         try:
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            self._save_binary_mask()
             segment_image_cropped(self.cfg, fname, x1, y1, x2, y2)
             self._hint("Super‑pixels updated")
         except Exception as e:

--- a/setup.ps1
+++ b/setup.ps1
@@ -10,7 +10,7 @@ $VENV_DIR = ".venv"
 try {
     $pythonVersionOutput = & python --version 2>&1
 } catch {
-    Write-Host "❌ Error: Python is not installed or not found in PATH."
+    Write-Host "Error: Python is not installed or not found in PATH."
     Write-Host "Please install Python 3.12 and try again."
     exit 1
 }
@@ -21,7 +21,7 @@ if ($pythonVersionOutput -match 'Python (\d+)\.(\d+)') {
     $minor = [int]$matches[2]
     $PYTHON_VERSION = "$major.$minor"
 } else {
-    Write-Host "❌ Could not parse Python version."
+    Write-Host "Could not parse Python version."
     exit 1
 }
 
@@ -41,7 +41,7 @@ function VersionCompare($v1, $v2) {
 }
 
 if (VersionCompare $PYTHON_VERSION $REQUIRED_VERSION -lt 0) {
-    Write-Host "⚠️ Warning: Detected Python $PYTHON_VERSION. This project is tested with Python $REQUIRED_VERSION."
+    Write-Host "Warning: Detected Python $PYTHON_VERSION. This project is tested with Python $REQUIRED_VERSION."
     Write-Host "    Proceeding anyway, but results may vary."
 }
 
@@ -53,7 +53,7 @@ python -m venv $VENV_DIR
 Write-Host "Activating virtual environment..."
 $activateScript = Join-Path $VENV_DIR "Scripts\Activate.ps1"
 if (-Not (Test-Path $activateScript)) {
-    Write-Host "❌ Could not find virtual environment activation script at $activateScript"
+    Write-Host "Could not find virtual environment activation script at $activateScript"
     exit 1
 }
 # Dot-source the activation script to activate virtual env in current session
@@ -72,6 +72,6 @@ Write-Host "Registering Jupyter kernel..."
 python -m ipykernel install --user --name $ENV_NAME --display-name "Python ($ENV_NAME)"
 
 # --- Final message ---
-Write-Host "✅ Setup complete."
+Write-Host "Setup complete."
 Write-Host "To activate the environment in future, run:"
 Write-Host "  .\$VENV_DIR\Scripts\Activate.ps1"

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ VENV_DIR=".venv"
 
 # --- Check if Python is installed ---
 if ! command -v python3 &> /dev/null; then
-    echo "❌ Error: Python is not installed or not found in PATH."
+    echo "Error: Python is not installed or not found in PATH."
     echo "Please install Python 3.12 and try again."
     exit 1
 fi
@@ -16,7 +16,7 @@ PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_inf
 REQUIRED_VERSION="3.12"
 
 if [[ "$(printf '%s\n' "$REQUIRED_VERSION" "$PYTHON_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]]; then
-    echo "⚠️ Warning: Detected Python $PYTHON_VERSION. This project is tested with Python 3.12."
+    echo "Warning: Detected Python $PYTHON_VERSION. This project is tested with Python 3.12."
     echo "    Proceeding anyway, but results may vary."
 fi
 
@@ -41,6 +41,6 @@ echo "Registering Jupyter kernel..."
 python -m ipykernel install --user --name "$ENV_NAME" --display-name "Python ($ENV_NAME)"
 
 # --- Final message ---
-echo "✅ Setup complete."
+echo "Setup complete."
 echo "To activate the environment, run:"
 echo "  source $VENV_DIR/bin/activate"


### PR DESCRIPTION
- Save binary mask before superpixel recreation to ensure intended behavior: 
  - New superpixels are only selected if they contain at least one pixel previously marked by the segmentation mask (via  already selected old superpixels). 



- Additionally:
Remove non-ASCII (Unicode) characters from setup scripts for improved compatibility.